### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/kartoza/QGIS.png?label=ready&title=Ready)](https://waffle.io/kartoza/QGIS)
 # About QGIS
 
 [![Build Status](https://travis-ci.org/qgis/QGIS.svg?branch=master)](https://travis-ci.org/qgis/QGIS)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/kartoza/QGIS

This was requested by a real person (user gubuntu) on waffle.io, we're not trying to spam you.